### PR TITLE
I2C->LCD Integration

### DIFF
--- a/src/main/arduino/Motion/LCD.cpp
+++ b/src/main/arduino/Motion/LCD.cpp
@@ -23,14 +23,6 @@ void LCD::begin() {
   delay(10);
   print("...");
 
-  define_character("?D11010101010101010");
-  define_character("?D21818181818181818");
-  define_character("?D31c1c1c1c1c1c1c1c");
-  define_character("?D41e1e1e1e1e1e1e1e");
-  define_character("?D51f1f1f1f1f1f1f1f");
-  define_character("?D60000000000040E1F");
-  define_character("?D70000000103070F1F");
-
   disable_cursor();
   delay(300);
 }
@@ -60,14 +52,6 @@ void LCD::set_cursor_row(byte row) {
 
 void LCD::set_cursor_column(byte column) {
   print("?x%02d", column);
-}
-
-void LCD::underline_cursor() {
-  print("?c3");
-}
-
-void LCD::blink_cursor() {
-  print("?c2");
 }
 
 void LCD::disable_cursor() {

--- a/src/main/arduino/Motion/LCD.h
+++ b/src/main/arduino/Motion/LCD.h
@@ -14,8 +14,6 @@ class LCD {
     void set_cursor(byte row, byte column);
     void set_cursor_row(byte row);
     void set_cursor_column(byte column);
-    void underline_cursor();
-    void blink_cursor();
     void disable_cursor();
     void print(char const *fmt, ... );
 

--- a/src/main/arduino/Motion/Motion.ino
+++ b/src/main/arduino/Motion/Motion.ino
@@ -31,11 +31,9 @@ void requestEvent() {
 
 void receiveEvent(int howMany) {
   lcd.clear_screen();
-  while (1 < Wire.available()) { // loop through all but the last
-    char c = Wire.read(); // receive byte as a character
+  
+  while (0 < Wire.available()) {
+    char c = Wire.read();
     lcd.print("%c", c);
   }
-  int x = Wire.read();    // receive byte as an integer
-
-  lcd.print("%d", x);
 }

--- a/src/main/arduino/Motion/Motion.ino
+++ b/src/main/arduino/Motion/Motion.ino
@@ -32,6 +32,19 @@ void requestEvent() {
 void receiveEvent(int howMany) {
   lcd.clear_screen();
   
+  if(0 >= Wire.available())
+  {
+    return;
+  }
+  
+  byte internal_address = Wire.read();
+  
+  lcd.set_cursor(0, 0);
+  lcd.print("Int Addr: 0x%02X", internal_address);
+  lcd.set_cursor(1, 0);
+  lcd.print("Data:", internal_address);
+  lcd.set_cursor(2, 0);
+  
   while (0 < Wire.available()) {
     char c = Wire.read();
     lcd.print("%c", c);

--- a/src/main/arduino/Motion/Motion.ino
+++ b/src/main/arduino/Motion/Motion.ino
@@ -2,11 +2,14 @@
 #include "LCD.h"
 
 #define I2C_ADDRESS 0x1A
+#define I2C_BUFFER_SIZE 32
 #define LCD_TX_PIN 10
 #define LCD_ROWS 4
 #define LCD_COLUMNS 20
+#define LCD_ADDRESS 0x01
 
 LCD lcd = LCD(LCD_TX_PIN, LCD_ROWS, LCD_COLUMNS);
+char i2c_buffer[I2C_BUFFER_SIZE];
 
 void setup() {
   Wire.begin(I2C_ADDRESS);
@@ -30,23 +33,37 @@ void requestEvent() {
 }
 
 void receiveEvent(int howMany) {
-  lcd.clear_screen();
-  
-  if(0 >= Wire.available())
+  if (0 >= Wire.available())
   {
     return;
   }
-  
+
   byte internal_address = Wire.read();
-  
-  lcd.set_cursor(0, 0);
-  lcd.print("Int Addr: 0x%02X", internal_address);
-  lcd.set_cursor(1, 0);
-  lcd.print("Data:", internal_address);
-  lcd.set_cursor(2, 0);
-  
-  while (0 < Wire.available()) {
-    char c = Wire.read();
-    lcd.print("%c", c);
+  int data_size = get_data();
+
+  switch (internal_address) {
+    case LCD_ADDRESS:
+      lcd.print(i2c_buffer);
+      break;
   }
 }
+
+int get_data()
+{
+  int index = 0;
+
+  memset(i2c_buffer, 0x00, sizeof(i2c_buffer));
+
+  while (0 < Wire.available()) {
+    if (I2C_BUFFER_SIZE <= index)
+    {
+      break;
+    }
+
+    i2c_buffer[index] = Wire.read();
+    index++;
+  }
+
+  return index;
+}
+

--- a/src/main/arduino/Motion/Motion.ino
+++ b/src/main/arduino/Motion/Motion.ino
@@ -14,28 +14,15 @@ void setup() {
   Wire.onRequest(requestEvent);
   lcd.begin();
   lcd.clear_screen();
+  lcd.set_brightness(0x77);
+  lcd.set_cursor(1, 5);
+  lcd.print("Pathfinder");
+  lcd.set_cursor(2, 7);
+  lcd.print("Online");
 }
 
 void loop() {
-  lcd.set_brightness(0x00);
-  delay(1000);
-  lcd.set_brightness(0x22);
-  delay(1000);
-  lcd.set_brightness(0x44);
-  delay(1000);
-  lcd.set_brightness(0xFF);
-  delay(1000);
-
-  lcd.set_cursor(1, 5);
-  lcd.print("Hello!");
-  delay(1000);
-  lcd.set_cursor(2, 10);
-  lcd.print("Howdy!");
-  delay(1000);
-  lcd.blink_cursor();
-  delay(1000);
-  lcd.disable_cursor();
-  lcd.clear_screen();
+  delay(100);
 }
 
 void requestEvent() {
@@ -43,8 +30,12 @@ void requestEvent() {
 }
 
 void receiveEvent(int howMany) {
+  lcd.clear_screen();
   while (1 < Wire.available()) { // loop through all but the last
     char c = Wire.read(); // receive byte as a character
+    lcd.print("%c", c);
   }
   int x = Wire.read();    // receive byte as an integer
+
+  lcd.print("%d", x);
 }


### PR DESCRIPTION
Uses the internal address to determine if the command is for the LCD. If so, it safely reads the data off I2C using a 32 byte buffer. 

Also, got rid of some LCD functions we won't use here. They'll be left to callers upstream to figure out.
